### PR TITLE
도서관 신착도서 스크래핑 API

### DIFF
--- a/biblebot/api/__init__.py
+++ b/biblebot/api/__init__.py
@@ -24,6 +24,8 @@ from .library import Login as LibraryLogin
 from .library import CheckoutList as LibraryCheckoutList
 from .library import BookDetail as LibraryBookDetail
 from .library import BookPhoto as LibraryBookPhoto
+from .library import NewBookPath as LibraryNewBookPath
+from .library import BookIntro as LibraryBookIntro
 
 
 __all__ = (
@@ -76,3 +78,5 @@ class LibraryAPI:
     CheckoutList = LibraryCheckoutList
     BookDetail = LibraryBookDetail
     BookPhoto = LibraryBookPhoto
+    NewBookPath = LibraryNewBookPath
+    BookIntro = LibraryBookIntro

--- a/biblebot/api/__init__.py
+++ b/biblebot/api/__init__.py
@@ -26,6 +26,7 @@ from .library import BookDetail as LibraryBookDetail
 from .library import BookPhoto as LibraryBookPhoto
 from .library import NewBookPath as LibraryNewBookPath
 from .library import BookIntro as LibraryBookIntro
+from .library import NewBookPathChange as LibraryNewBookPathChange
 
 
 __all__ = (
@@ -80,3 +81,4 @@ class LibraryAPI:
     BookPhoto = LibraryBookPhoto
     NewBookPath = LibraryNewBookPath
     BookIntro = LibraryBookIntro
+    NewBookPathChange = LibraryNewBookPathChange

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -10,6 +10,7 @@ BookDetail과 BookPhoto를 통해
 from typing import Dict, Optional, List, Tuple
 from dataclasses import dataclass
 from base64 import b64encode
+import unicodedata
 import re
 
 from .base import (
@@ -224,5 +225,6 @@ class BookIntro:
         div = soup.find(class_="sponge-page-guide")
         title = div.find("strong", attrs={"class": "sponge-book-title"}).get_text()
         introduction = div.find("div", attrs={"id": "bookIntroContent"}).get_text()
+        introduction = unicodedata.normalize("NFKD", introduction)
 
         return [title, introduction]

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -204,7 +204,9 @@ class NewBookPath:
     def parse(cls, response: Response) -> List[str]:
         soup = response.soup
         new_book_path_list = soup.select(".sponge-newbook-list > li")
-        new_book_path_list = [book.select_one("a")["href"] for book in new_book_path_list]
+        new_book_path_list = [
+            book.select_one("a")["href"] for book in new_book_path_list
+        ]
 
         return new_book_path_list
 
@@ -231,12 +233,19 @@ class BookIntro:
         div = soup.find(class_="sponge-page-guide")
         try:
             introduction = div.find("div", attrs={"id": "bookIntroContent"}).get_text()
-            introduction = unicodedata.normalize("NFKD", introduction)
-
-            find = re.compile(r"^([^.]+\.{1,3}){2}")
-            introduction = re.search(find, introduction).group()
         except AttributeError:
-            introduction = None
+            return None
+
+        introduction = unicodedata.normalize("NFKD", introduction)
+        count = 1
+        while len(introduction) > 300:
+            temp = re.search(fr"^([^.]+\.{{1,3}}){{{count}}}", introduction).group()
+            if len(temp) < 100:
+                count += 1
+                continue
+            else:
+                introduction = temp
+                break
 
         return introduction
 

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -32,6 +32,7 @@ __all__ = (
     "BookPhoto",
     "NewBookPath",
     "BookIntro",
+    "NewBookPathChange",
 )
 
 DOMAIN_NAME: str = "https://lib.bible.ac.kr"
@@ -184,6 +185,7 @@ class BookPhoto:
             return ResourceData(data={"raw_image": response.raw}, link=response.url)
 
 
+# TODO: 21-1학기 현재 사용하지 않지만 상황을 봐서 남겨둔 코드
 class NewBookPath:
     URL: str = DOMAIN_NAME + "/Search/New"
 
@@ -237,3 +239,24 @@ class BookIntro:
             introduction = None
 
         return introduction
+
+
+class NewBookPathChange:
+    @classmethod
+    async def fetch(
+        cls,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Response:
+        return await HTTPClient.connector.get(
+            DOMAIN_NAME, headers=headers, timeout=timeout, **kwargs
+        )
+
+    @classmethod
+    def parse(cls, response: Response) -> List[str]:
+        soup = response.soup
+        ul = soup.select_one("#book-new > div ul")
+        tag_list = ul.select("li")
+        path_list = [tag.select_one("a")["href"] for tag in tag_list]
+        return path_list

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -226,4 +226,7 @@ class BookIntro:
         introduction = div.find("div", attrs={"id": "bookIntroContent"}).get_text()
         introduction = unicodedata.normalize("NFKD", introduction)
 
+        find = re.compile(r"^(([^.]*).){2}")
+        introduction = re.search(find, introduction).group()
+
         return [title, introduction]

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -231,7 +231,7 @@ class BookIntro:
             introduction = div.find("div", attrs={"id": "bookIntroContent"}).get_text()
             introduction = unicodedata.normalize("NFKD", introduction)
 
-            find = re.compile(r"^(([^.]*).){2}")
+            find = re.compile(r"^([^.]+\.{1,3}){2}")
             introduction = re.search(find, introduction).group()
         except AttributeError:
             introduction = None

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -7,7 +7,6 @@ CheckoutList를 통해
 BookDetail과 BookPhoto를 통해
 ['ISBN', '서지정보', '대출일자', '반납예정일', '대출상태', '연기신청', '도서이미지']의 데이터가 완성된다.
 """
-import unicodedata
 from typing import Dict, Optional, List, Tuple
 from base64 import b64encode
 import unicodedata

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -7,6 +7,7 @@ BookDetail과 BookPhoto를 통해
 ['ISBN', '서지정보', '대출일자', '반납예정일', '대출상태', '연기신청', '도서이미지']의 데이터가 완성된다.
 """
 from typing import Dict, Optional, List, Tuple
+from dataclasses import dataclass
 from base64 import b64encode
 import re
 
@@ -35,6 +36,13 @@ __all__ = (
 DOMAIN_NAME: str = "https://lib.bible.ac.kr"
 
 _ParserPrecondition = ParserPrecondition(IParserPrecondition)
+
+
+@dataclass
+class NewBookData:
+    title: str
+    introduction: str
+    img: str
 
 
 class _SessionExpiredChecker(IParserPrecondition):

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -8,7 +8,6 @@ BookDetail과 BookPhoto를 통해
 ['ISBN', '서지정보', '대출일자', '반납예정일', '대출상태', '연기신청', '도서이미지']의 데이터가 완성된다.
 """
 from typing import Dict, Optional, List, Tuple
-from dataclasses import dataclass
 from base64 import b64encode
 import unicodedata
 import re

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -1,4 +1,5 @@
 """
+##### 대출목록 기능 #####
 CheckoutList → BookDetail → BookPhoto를 거쳐야만 데이터가 취합되는 구조이다.
 CheckoutList를 통해
 ['No', '서지정보', '대출일자', '반납예정일', '대출상태', '연기신청', '상세페이지 URL']의 데이터가
@@ -7,7 +8,6 @@ BookDetail과 BookPhoto를 통해
 ['ISBN', '서지정보', '대출일자', '반납예정일', '대출상태', '연기신청', '도서이미지']의 데이터가 완성된다.
 """
 from typing import Dict, Optional, List, Tuple
-from dataclasses import dataclass
 from base64 import b64encode
 import re
 
@@ -36,13 +36,6 @@ __all__ = (
 DOMAIN_NAME: str = "https://lib.bible.ac.kr"
 
 _ParserPrecondition = ParserPrecondition(IParserPrecondition)
-
-
-@dataclass
-class NewBookData:
-    title: str
-    introduction: str
-    img: str
 
 
 class _SessionExpiredChecker(IParserPrecondition):
@@ -227,8 +220,8 @@ class BookIntro:
     @classmethod
     def parse(cls, response: Response) -> List[str]:
         soup = response.soup
-        div = soup.find(class_="sponge_cent_naver sponge-guide-Box")
-        title = div.find("img")["alt"]
-        introduction = soup.find(class_="dsc").text
+        div = soup.find(class_="sponge-page-guide")
+        title = div.find(class_="sponge-book-title")
+        introduction = div.find(id_="bookIntroContent")
 
         return [title, introduction]

--- a/biblebot/api/library.py
+++ b/biblebot/api/library.py
@@ -8,6 +8,7 @@ BookDetail과 BookPhoto를 통해
 ['ISBN', '서지정보', '대출일자', '반납예정일', '대출상태', '연기신청', '도서이미지']의 데이터가 완성된다.
 """
 from typing import Dict, Optional, List, Tuple
+from dataclasses import dataclass
 from base64 import b64encode
 import re
 
@@ -221,7 +222,7 @@ class BookIntro:
     def parse(cls, response: Response) -> List[str]:
         soup = response.soup
         div = soup.find(class_="sponge-page-guide")
-        title = div.find(class_="sponge-book-title")
-        introduction = div.find(id_="bookIntroContent")
+        title = div.find("strong", attrs={"class": "sponge-book-title"}).get_text()
+        introduction = div.find("div", attrs={"id": "bookIntroContent"}).get_text()
 
         return [title, introduction]


### PR DESCRIPTION
## 소개
- 크론봇에 사용할 API입니다.
- 신착도서 API는 대출목록 API에서 사용한 `BookDetail`과 `BookPhoto`클래스를 재사용합니다.

      BookDetail은 isbn과 이미지URL를 제공
      BookPhoto는 이미지바이트코드를 제공
     
## 사용법
신착도서 API는 `isbn`, `책제목(title)`, `소개글(introduction)`, `이미지(img)` 데이터를 제공합니다.

`NewBookPath`클래스와 `NewBookPathAtHomePage`클래스는 
    
    신착도서들의 각 상세페이지로 가는 경로를 스크래핑해옵니다.
    상세페이지에서 신착도서 API가 제공하는 데이터들이 있기 때문입니다.

`BookIntro`클래스는 
  
    책제목과 소개글을 스크래핑해옵니다.

신착도서를 얻는 과정은 https://github.com/rekyungmin/biblebot-cron/pull/1 의 
`new_book` 모듈의 `get_new_book_list`메소드에서 확인하실수 있습니다.